### PR TITLE
Feat: Member 기능 구현 (#15)

### DIFF
--- a/src/main/java/notai/auth/Auth.java
+++ b/src/main/java/notai/auth/Auth.java
@@ -1,0 +1,15 @@
+package notai.auth;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Hidden
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/notai/auth/AuthArgumentResolver.java
+++ b/src/main/java/notai/auth/AuthArgumentResolver.java
@@ -1,0 +1,37 @@
+package notai.auth;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import notai.member.domain.MemberRepository;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class)
+               && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Long resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Long memberId = (Long) request.getAttribute("memberId");
+        return memberRepository.getById(memberId).getId();
+    }
+}

--- a/src/main/java/notai/auth/TokenPair.java
+++ b/src/main/java/notai/auth/TokenPair.java
@@ -1,0 +1,4 @@
+package notai.auth;
+
+public record TokenPair(String accessToken, String refreshToken) {
+}

--- a/src/main/java/notai/auth/TokenProperty.java
+++ b/src/main/java/notai/auth/TokenProperty.java
@@ -1,0 +1,11 @@
+package notai.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("token")
+public record TokenProperty(
+        String secretKey,
+        long accessTokenExpirationMillis,
+        long refreshTokenExpirationMillis
+) {
+}

--- a/src/main/java/notai/auth/TokenService.java
+++ b/src/main/java/notai/auth/TokenService.java
@@ -1,0 +1,84 @@
+package notai.auth;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import notai.common.exception.type.UnAuthorizedException;
+import notai.member.domain.Member;
+import notai.member.domain.MemberRepository;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class TokenService {
+    private static final String MEMBER_ID_CLAIM = "memberId";
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpirationMillis;
+    private final long refreshTokenExpirationMillis;
+    private final MemberRepository memberRepository;
+
+    public TokenService(TokenProperty tokenProperty, MemberRepository memberRepository) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(tokenProperty.secretKey()));
+        this.accessTokenExpirationMillis = tokenProperty.accessTokenExpirationMillis();
+        this.refreshTokenExpirationMillis = tokenProperty.refreshTokenExpirationMillis();
+        this.memberRepository = memberRepository;
+    }
+
+    public String createAccessToken(Long memberId) {
+        return Jwts.builder()
+                .claim(MEMBER_ID_CLAIM, memberId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpirationMillis))
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    private String createRefreshToken() {
+        return Jwts.builder()
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpirationMillis))
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    public TokenPair createTokenPair(Long memberId) {
+        String accessToken = createAccessToken(memberId);
+        String refreshToken = createRefreshToken();
+
+        Member member = memberRepository.getById(memberId);
+        member.updateRefreshToken(refreshToken);
+        memberRepository.save(member);
+
+        return new TokenPair(accessToken, refreshToken);
+    }
+
+    public TokenPair refreshTokenPair(String refreshToken) {
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new UnAuthorizedException("만료된 Refresh Token입니다.");
+        } catch (Exception e) {
+            throw new UnAuthorizedException("유효하지 않은 Refresh Token입니다.");
+        }
+        Member member = memberRepository.getByRefreshToken(refreshToken);
+
+        return createTokenPair(member.getId());
+    }
+
+    public Long extractMemberId(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get(MEMBER_ID_CLAIM, Long.class);
+        } catch (Exception e) {
+            throw new UnAuthorizedException("유효하지 않은 토큰입니다.");
+        }
+    }
+}

--- a/src/main/java/notai/client/HttpInterfaceUtil.java
+++ b/src/main/java/notai/client/HttpInterfaceUtil.java
@@ -1,0 +1,13 @@
+package notai.client;
+
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+public class HttpInterfaceUtil {
+	public static <T> T createHttpInterface(RestClient restClient, Class<T> clazz) {
+		HttpServiceProxyFactory build = HttpServiceProxyFactory
+				.builderFor(RestClientAdapter.create(restClient)).build();
+		return build.createClient(clazz);
+	}
+}

--- a/src/main/java/notai/client/oauth/OauthClient.java
+++ b/src/main/java/notai/client/oauth/OauthClient.java
@@ -1,0 +1,11 @@
+package notai.client.oauth;
+
+import notai.member.domain.Member;
+import notai.member.domain.OauthProvider;
+
+public interface OauthClient {
+
+	OauthProvider oauthProvider();
+
+	Member fetchMember(String accessToken);
+}

--- a/src/main/java/notai/client/oauth/OauthClientComposite.java
+++ b/src/main/java/notai/client/oauth/OauthClientComposite.java
@@ -1,0 +1,33 @@
+package notai.client.oauth;
+
+import notai.common.exception.type.BadRequestException;
+import notai.member.domain.Member;
+import notai.member.domain.OauthProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+@Component
+public class OauthClientComposite {
+
+	private final Map<OauthProvider, OauthClient> oauthClients;
+
+	public OauthClientComposite(Set<OauthClient> oauthClients) {
+		this.oauthClients = oauthClients.stream()
+				.collect(toMap(OauthClient::oauthProvider, identity()));
+	}
+
+	public Member fetchMember(OauthProvider oauthProvider, String accessToken) {
+		return oauthClients.get(oauthProvider).fetchMember(accessToken);
+	}
+
+	public OauthClient getOauthClient(OauthProvider oauthProvider) {
+		return Optional.ofNullable(oauthClients.get(oauthProvider)).orElseThrow(
+				() -> new BadRequestException("지원하지 않는 소셜 로그인 타입입니다."));
+	}
+}

--- a/src/main/java/notai/client/oauth/kakao/KakaoClient.java
+++ b/src/main/java/notai/client/oauth/kakao/KakaoClient.java
@@ -1,0 +1,12 @@
+package notai.client.oauth.kakao;
+
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.service.annotation.GetExchange;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+public interface KakaoClient {
+
+    @GetExchange(url = "https://kapi.kakao.com/v2/user/me")
+    KakaoMemberResponse fetchMember(@RequestHeader(name = AUTHORIZATION) String accessToken);
+}

--- a/src/main/java/notai/client/oauth/kakao/KakaoClientConfig.java
+++ b/src/main/java/notai/client/oauth/kakao/KakaoClientConfig.java
@@ -1,0 +1,27 @@
+package notai.client.oauth.kakao;
+
+import lombok.extern.slf4j.Slf4j;
+import notai.common.exception.type.ExternalApiException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.RestClient;
+
+import static notai.client.HttpInterfaceUtil.createHttpInterface;
+
+@Slf4j
+@Configuration
+public class KakaoClientConfig {
+
+    @Bean
+    public KakaoClient kakaoClient() {
+        RestClient restClient = RestClient.builder()
+                .defaultStatusHandler(HttpStatusCode::isError, (request, response) -> {
+                    String responseData = new String(response.getBody().readAllBytes());
+                    log.error("카카오톡 API 오류 : {}", responseData);
+                    throw new ExternalApiException(responseData, response.getStatusCode().value());
+                })
+                .build();
+        return createHttpInterface(restClient, KakaoClient.class);
+    }
+}

--- a/src/main/java/notai/client/oauth/kakao/KakaoMemberResponse.java
+++ b/src/main/java/notai/client/oauth/kakao/KakaoMemberResponse.java
@@ -1,0 +1,38 @@
+package notai.client.oauth.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import notai.member.domain.Member;
+import notai.member.domain.OauthId;
+import notai.member.domain.OauthProvider;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(value = SnakeCaseStrategy.class)
+public record KakaoMemberResponse(
+		Long id,
+		boolean hasSignedUp,
+		LocalDateTime connectedAt,
+		KakaoAccount kakaoAccount) {
+
+	public Member toDomain() {
+		return new Member(
+				new OauthId(String.valueOf(id), OauthProvider.KAKAO),
+				kakaoAccount.email,
+				kakaoAccount.profile.nickname);
+	}
+
+	@JsonNaming(value = SnakeCaseStrategy.class)
+	public record KakaoAccount(
+			Profile profile,
+			boolean emailNeedsAgreement,
+			boolean isEmailValid,
+			boolean isEmailVerified,
+			String email) {
+	}
+
+	@JsonNaming(value = SnakeCaseStrategy.class)
+	public record Profile(
+			String nickname) {
+	}
+}

--- a/src/main/java/notai/client/oauth/kakao/KakaoOauthClient.java
+++ b/src/main/java/notai/client/oauth/kakao/KakaoOauthClient.java
@@ -1,0 +1,27 @@
+package notai.client.oauth.kakao;
+
+import lombok.RequiredArgsConstructor;
+import notai.client.oauth.OauthClient;
+import notai.member.domain.Member;
+import notai.member.domain.OauthProvider;
+import org.springframework.stereotype.Component;
+
+import static notai.member.domain.OauthProvider.KAKAO;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOauthClient implements OauthClient {
+
+    private final KakaoClient kakaoClient;
+
+    @Override
+    public Member fetchMember(String accessToken) {
+        return kakaoClient.fetchMember(accessToken).toDomain();
+    }
+
+    @Override
+    public OauthProvider oauthProvider() {
+        return KAKAO;
+    }
+
+}

--- a/src/main/java/notai/common/config/AuthConfig.java
+++ b/src/main/java/notai/common/config/AuthConfig.java
@@ -1,0 +1,30 @@
+package notai.common.config;
+
+import lombok.RequiredArgsConstructor;
+import notai.auth.AuthArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class AuthConfig implements WebMvcConfigurer {
+    private final AuthInterceptor authInterceptor;
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/members/oauth/login/**")
+                .excludePathPatterns("/api/members/token/refresh");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+}

--- a/src/main/java/notai/common/config/AuthInterceptor.java
+++ b/src/main/java/notai/common/config/AuthInterceptor.java
@@ -1,0 +1,35 @@
+package notai.common.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import notai.auth.TokenService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+    private final TokenService tokenService;
+    private static final String AUTHENTICATION_TYPE = "Bearer ";
+    private static final int BEARER_PREFIX_LENGTH = 7;
+
+    public AuthInterceptor(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String header = request.getHeader(AUTHORIZATION);
+        if (header == null || !header.startsWith(AUTHENTICATION_TYPE)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        String token = header.substring(BEARER_PREFIX_LENGTH);
+        Long memberId = tokenService.extractMemberId(token);
+        request.setAttribute("memberId", memberId);
+
+        return true;
+    }
+}

--- a/src/main/java/notai/common/config/WebConfig.java
+++ b/src/main/java/notai/common/config/WebConfig.java
@@ -1,8 +1,0 @@
-package notai.common.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-@Configuration
-public class WebConfig implements WebMvcConfigurer {
-}

--- a/src/main/java/notai/member/application/MemberQueryService.java
+++ b/src/main/java/notai/member/application/MemberQueryService.java
@@ -1,0 +1,17 @@
+package notai.member.application;
+
+import lombok.RequiredArgsConstructor;
+import notai.member.application.result.MemberFindResult;
+import notai.member.domain.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberFindResult findById(Long memberId) {
+        return MemberFindResult.from(memberRepository.getById(memberId));
+    }
+}

--- a/src/main/java/notai/member/application/MemberService.java
+++ b/src/main/java/notai/member/application/MemberService.java
@@ -1,0 +1,21 @@
+package notai.member.application;
+
+import lombok.RequiredArgsConstructor;
+import notai.member.domain.Member;
+import notai.member.domain.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Long login(Member member) {
+        return memberRepository.findByOauthId(member.getOauthId())
+                .orElseGet(() -> memberRepository.save(member))
+                .getId();
+    }
+}

--- a/src/main/java/notai/member/application/result/MemberFindResult.java
+++ b/src/main/java/notai/member/application/result/MemberFindResult.java
@@ -1,0 +1,15 @@
+package notai.member.application.result;
+
+import notai.member.domain.Member;
+
+public record MemberFindResult(
+        Long id,
+        String nickname
+) {
+    public static MemberFindResult from(Member member) {
+        return new MemberFindResult(
+                member.getId(),
+                member.getNickname()
+        );
+    }
+}

--- a/src/main/java/notai/member/domain/Member.java
+++ b/src/main/java/notai/member/domain/Member.java
@@ -1,0 +1,44 @@
+package notai.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import notai.common.domain.RootEntity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+public class Member extends RootEntity<Long> {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@Embedded
+	private OauthId oauthId;
+
+	@Column(length = 50, nullable = false)
+	private String email;
+
+	@Column(length = 20, nullable = true)
+	private String nickname;
+
+	@Column(length = 255, nullable = false)
+	private String refreshToken;
+
+	public Member(OauthId oauthId, String email, String nickname) {
+		this.oauthId = oauthId;
+		this.email = email;
+		this.nickname = nickname;
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/notai/member/domain/MemberRepository.java
+++ b/src/main/java/notai/member/domain/MemberRepository.java
@@ -1,0 +1,24 @@
+package notai.member.domain;
+
+import notai.common.exception.type.NotFoundException;
+import notai.common.exception.type.UnAuthorizedException;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthId(OauthId oauthId);
+
+    default Member getById(Long id) {
+        return findById(id).orElseThrow(() ->
+                new NotFoundException("회원 정보를 찾을 수 없습니다.")
+        );
+    }
+
+    Optional<Member> findByRefreshToken(String refreshToken);
+
+    default Member getByRefreshToken(String refreshToken) {
+        return findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new UnAuthorizedException("유효하지 않은 Refresh Token입니다."));
+    }
+}

--- a/src/main/java/notai/member/domain/OauthId.java
+++ b/src/main/java/notai/member/domain/OauthId.java
@@ -1,0 +1,25 @@
+package notai.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class OauthId {
+
+	@Column(length = 255, nullable = false)
+	private String oauthId;
+
+	@Enumerated(STRING)
+	@Column(length = 20, nullable = false)
+	private OauthProvider oauthProvider;
+}

--- a/src/main/java/notai/member/domain/OauthProvider.java
+++ b/src/main/java/notai/member/domain/OauthProvider.java
@@ -1,0 +1,5 @@
+package notai.member.domain;
+
+public enum OauthProvider {
+	KAKAO
+}

--- a/src/main/java/notai/member/presentation/MemberController.java
+++ b/src/main/java/notai/member/presentation/MemberController.java
@@ -1,0 +1,55 @@
+package notai.member.presentation;
+
+import lombok.RequiredArgsConstructor;
+import notai.auth.Auth;
+import notai.auth.TokenPair;
+import notai.auth.TokenService;
+import notai.client.oauth.OauthClientComposite;
+import notai.member.application.MemberQueryService;
+import notai.member.application.MemberService;
+import notai.member.domain.Member;
+import notai.member.domain.OauthProvider;
+import notai.member.presentation.request.OauthLoginRequest;
+import notai.member.presentation.request.TokenRefreshRequest;
+import notai.member.presentation.response.MemberFindResponse;
+import notai.member.presentation.response.MemberOauthLoginResopnse;
+import notai.member.presentation.response.MemberTokenRefreshResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/members/")
+public class MemberController {
+
+    private final MemberService memberService;
+    private final MemberQueryService memberQueryService;
+    private final OauthClientComposite oauthClient;
+    private final TokenService tokenService;
+
+    @PostMapping("/oauth/login/{oauthProvider}")
+    public ResponseEntity<MemberOauthLoginResopnse> loginWithOauth(
+            @PathVariable(value = "oauthProvider") OauthProvider oauthProvider,
+            @RequestBody OauthLoginRequest request
+    ) {
+        Member member = oauthClient.fetchMember(oauthProvider, request.oauthAccessToken());
+        Long memberId = memberService.login(member);
+        TokenPair tokenPair = tokenService.createTokenPair(memberId);
+        return ResponseEntity.ok(MemberOauthLoginResopnse.from(tokenPair));
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<MemberTokenRefreshResponse> refreshToken(
+            @RequestBody TokenRefreshRequest request
+    ) {
+        TokenPair tokenPair = tokenService.refreshTokenPair(request.refreshToken());
+        return ResponseEntity.ok(MemberTokenRefreshResponse.from(tokenPair));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberFindResponse> findMyProfile(
+            @Auth Long memberId
+    ) {
+        return ResponseEntity.ok(MemberFindResponse.from(memberQueryService.findById(memberId)));
+    }
+}

--- a/src/main/java/notai/member/presentation/request/OauthLoginRequest.java
+++ b/src/main/java/notai/member/presentation/request/OauthLoginRequest.java
@@ -1,0 +1,6 @@
+package notai.member.presentation.request;
+
+public record OauthLoginRequest(
+        String oauthAccessToken
+) {
+}

--- a/src/main/java/notai/member/presentation/request/TokenRefreshRequest.java
+++ b/src/main/java/notai/member/presentation/request/TokenRefreshRequest.java
@@ -1,0 +1,6 @@
+package notai.member.presentation.request;
+
+public record TokenRefreshRequest(
+        String refreshToken
+) {
+}

--- a/src/main/java/notai/member/presentation/response/MemberFindResponse.java
+++ b/src/main/java/notai/member/presentation/response/MemberFindResponse.java
@@ -1,0 +1,15 @@
+package notai.member.presentation.response;
+
+import notai.member.application.result.MemberFindResult;
+
+public record MemberFindResponse(
+        Long id,
+        String nickname
+) {
+    public static MemberFindResponse from(MemberFindResult result) {
+        return new MemberFindResponse(
+                result.id(),
+                result.nickname()
+        );
+    }
+}

--- a/src/main/java/notai/member/presentation/response/MemberOauthLoginResopnse.java
+++ b/src/main/java/notai/member/presentation/response/MemberOauthLoginResopnse.java
@@ -1,0 +1,12 @@
+package notai.member.presentation.response;
+
+import notai.auth.TokenPair;
+
+public record MemberOauthLoginResopnse(
+        String accessToken,
+        String refreshToken
+) {
+    public static MemberOauthLoginResopnse from(TokenPair tokenPair) {
+        return new MemberOauthLoginResopnse(tokenPair.accessToken(), tokenPair.refreshToken());
+    }
+}

--- a/src/main/java/notai/member/presentation/response/MemberTokenRefreshResponse.java
+++ b/src/main/java/notai/member/presentation/response/MemberTokenRefreshResponse.java
@@ -1,0 +1,12 @@
+package notai.member.presentation.response;
+
+import notai.auth.TokenPair;
+
+public record MemberTokenRefreshResponse(
+        String accessToken,
+        String refreshToken
+)  {
+    public static MemberTokenRefreshResponse from(TokenPair tokenPair) {
+        return new MemberTokenRefreshResponse(tokenPair.accessToken(), tokenPair.refreshToken());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,3 +34,8 @@ server:
       force: true
 
 server-url: http://localhost:8080
+
+token: # todo production에서 secretKey 변경
+  secretKey: "ZGQrT0tuZHZkRWRxeXJCamRYMDFKMnBaR2w5WXlyQm9HU2RqZHNha1gycFlkMWpLc0dObw=="
+  accessTokenExpirationMillis: 10000000000
+  refreshTokenExpirationMillis: 10000000000

--- a/src/test/java/notai/client/oauth/kakao/KakaoOauthClientTest.java
+++ b/src/test/java/notai/client/oauth/kakao/KakaoOauthClientTest.java
@@ -1,0 +1,60 @@
+package notai.client.oauth.kakao;
+
+import notai.member.domain.Member;
+import notai.member.domain.OauthProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class KakaoOauthClientTest {
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @InjectMocks
+    private KakaoOauthClient kakaoOauthClient;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testFetchMember() {
+        long id = 12345L;
+        String accessToken = "testAccessToken";
+        String email = "email@example.com";
+        boolean isEmailVerified = true;
+        boolean isEmailValid = true;
+        boolean emailNeedsAgreement = false;
+        LocalDateTime connectedAt = LocalDateTime.now();
+        boolean hasSignedUp = true;
+        String nickname = "nickname";
+        KakaoMemberResponse.Profile profile = new KakaoMemberResponse.Profile(nickname);
+
+        KakaoMemberResponse.KakaoAccount kakaoAccount = new KakaoMemberResponse.KakaoAccount(
+                profile,
+                emailNeedsAgreement,
+                isEmailValid,
+                isEmailVerified,
+                email);
+
+        KakaoMemberResponse kakaoMemberResponse = new KakaoMemberResponse(id, hasSignedUp, connectedAt, kakaoAccount);
+
+        when(kakaoClient.fetchMember(accessToken)).thenReturn(kakaoMemberResponse);
+
+        Member member = kakaoOauthClient.fetchMember(accessToken);
+
+        assertEquals(String.valueOf(id), member.getOauthId().getOauthId());
+        assertEquals(OauthProvider.KAKAO, member.getOauthId().getOauthProvider());
+        assertEquals(nickname, member.getNickname());
+        assertEquals(email, member.getEmail());
+    }
+}


### PR DESCRIPTION
* Feat: Member 도메인 구현

* Feat: Kakao 로그인 Client로직 구현

- 안드로이드에서 전달 된 이미 검증이 된 Kakao accesstoken으로 Member조회

* Test: Kakao 로그인 fetchMember 단위테스트 작성

* Feat: JWT 관련 기능 구현

- Interceptor에서 특정 path를 제외하고 토큰이 유효한지 검증
- @Auth 어노테이션이 붙어있으면서 Long타입인 파라미터인 경우 ArgumentResolver에서 토큰검증 및 memberId를 반환해주도록 구현

* Feat: Member API 구현

* Style: 불필요한 import 제거

* Test: 하드코딩 된 값 변수추출

* Refactor: 불필요한 토큰 검증 제거

- Interceptor에서 검증된 토큰으로 memberId를 추출해 ArgumenResolver에서 그 memberId를 사용할 수 있도록 개선

## 🔎 작업 내용

> Member Kakao 로그인 구현 및 JWT적용



## ➕ 이슈 링크

Closes https://github.com/kakao-tech-campus-2nd-step3/Team29_BE/issues/11
Closes https://github.com/kakao-tech-campus-2nd-step3/Team29_BE/issues/12
Closes https://github.com/kakao-tech-campus-2nd-step3/Team29_BE/issues/13
