### PR TITLE
Feat: Post  기능 구현  -Member 연관관계 매핑

### DIFF
--- a/src/main/java/notai/post/application/PostQueryService.java
+++ b/src/main/java/notai/post/application/PostQueryService.java
@@ -1,0 +1,4 @@
+package notai.post.application;
+
+public class PostQueryService {
+}

--- a/src/main/java/notai/post/application/PostService.java
+++ b/src/main/java/notai/post/application/PostService.java
@@ -1,0 +1,4 @@
+package notai.post.application;
+
+public class PostService {
+}

--- a/src/main/java/notai/post/domain/Post.java
+++ b/src/main/java/notai/post/domain/Post.java
@@ -1,0 +1,38 @@
+package notai.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Post {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private Long memberId;
+    @Column(length = 255, nullable = false)
+    private String title;
+    @Column(length = 255, nullable = false)
+    private String contents;
+
+    public Post(
+            Long memberId,
+            String title,
+            String contents
+    ) {
+        this.memberId = memberId;
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/notai/post/domain/Post.java
+++ b/src/main/java/notai/post/domain/Post.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,11 +24,14 @@ public class Post {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
     @ManyToOne
+    @NotNull
     @JoinColumn(name="member_id")
     private Member member;
-    @Column(length = 255, nullable = false)
+    @NotNull
+    @Column(length = 255)
     private String title;
-    @Column(length = 255, nullable = false)
+    @NotNull
+    @Column(length = 255)
     private String contents;
 
     public Post(

--- a/src/main/java/notai/post/domain/Post.java
+++ b/src/main/java/notai/post/domain/Post.java
@@ -4,9 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import notai.member.domain.Member;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -19,19 +22,20 @@ public class Post {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
-    @Column(nullable = false)
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name="member_id")
+    private Member member;
     @Column(length = 255, nullable = false)
     private String title;
     @Column(length = 255, nullable = false)
     private String contents;
 
     public Post(
-            Long memberId,
+            Member member,
             String title,
             String contents
     ) {
-        this.memberId = memberId;
+        this.member = member;
         this.title = title;
         this.contents = contents;
     }

--- a/src/main/java/notai/post/domain/PostRepository.java
+++ b/src/main/java/notai/post/domain/PostRepository.java
@@ -1,0 +1,9 @@
+package notai.post.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/notai/post/presentation/PostController.java
+++ b/src/main/java/notai/post/presentation/PostController.java
@@ -1,0 +1,4 @@
+package notai.post.presentation;
+
+public class PostController {
+}


### PR DESCRIPTION
## 🔎 작업 내용

> 이전에 작성한 코드에서, Member 와 연관관계 매핑 해주었습니다. 


## 💬 리뷰 요구사항 (선택)

>  MemberId를 Long 타입으로 저장하지말고 나중에 그냥 Member 객체를 아예 저장하고 나중에 필요할때마다 .getId() 로 따로 갔다 쓰면 되는거 맞나요 


## 📸 이미지 첨부 (선택)



## ➕ 이슈 링크

작업중 ;  https://github.com/kakao-tech-campus-2nd-step3/Team29_BE/issues/6
