### PR TITLE
Feat: Post 저장 기능 구현

### DIFF
--- a/src/main/java/notai/post/application/PostService.java
+++ b/src/main/java/notai/post/application/PostService.java
@@ -1,4 +1,24 @@
 package notai.post.application;
 
+import lombok.RequiredArgsConstructor;
+import notai.member.domain.Member;
+import notai.member.domain.MemberRepository;
+import notai.post.application.result.PostSaveResult;
+import notai.post.domain.Post;
+import notai.post.domain.PostRepository;
+import notai.post.presentation.request.PostSaveRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class PostService {
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    public PostSaveResult savePost(PostSaveRequest postSaveRequest) {
+        Member member = memberRepository.getById(postSaveRequest.memberId());
+        Post post = new Post(member, postSaveRequest.title(), postSaveRequest.content());
+        Post savedPost = postRepository.save(post);
+        return PostSaveResult.of(savedPost.getId(), savedPost.getTitle());
+    }
 }

--- a/src/main/java/notai/post/application/result/PostSaveResult.java
+++ b/src/main/java/notai/post/application/result/PostSaveResult.java
@@ -1,0 +1,10 @@
+package notai.post.application.result;
+
+public record PostSaveResult(
+        Long id,
+        String title
+) {
+    public static PostSaveResult of(Long id, String title) {
+        return new PostSaveResult(id, title);
+    }
+}

--- a/src/main/java/notai/post/domain/Post.java
+++ b/src/main/java/notai/post/domain/Post.java
@@ -1,15 +1,14 @@
 package notai.post.domain;
 
 import jakarta.persistence.*;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
 import jakarta.validation.constraints.NotNull;
+import static lombok.AccessLevel.PROTECTED;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import notai.member.domain.Member;
-
-import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/java/notai/post/presentation/PostController.java
+++ b/src/main/java/notai/post/presentation/PostController.java
@@ -1,4 +1,34 @@
 package notai.post.presentation;
 
+import lombok.RequiredArgsConstructor;
+import notai.post.application.PostService;
+import notai.post.application.result.PostSaveResult;
+import notai.post.presentation.request.PostSaveRequest;
+import notai.post.presentation.response.PostSaveResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
 public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    public ResponseEntity<PostSaveResponse> savePost(
+            @RequestBody PostSaveRequest postSaveRequest
+    ) {
+        PostSaveResult postSaveResult;
+        postSaveResult = postService.savePost(postSaveRequest);
+        PostSaveResponse response = PostSaveResponse.from(postSaveResult);
+        String url = String.format("/api/post/%s", response.id());
+        return ResponseEntity.created(URI.create(url)).body(response);
+    }
+
 }

--- a/src/main/java/notai/post/presentation/request/PostSaveRequest.java
+++ b/src/main/java/notai/post/presentation/request/PostSaveRequest.java
@@ -1,0 +1,8 @@
+package notai.post.presentation.request;
+
+public record PostSaveRequest(
+        Long memberId,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/notai/post/presentation/response/PostSaveResponse.java
+++ b/src/main/java/notai/post/presentation/response/PostSaveResponse.java
@@ -1,0 +1,12 @@
+package notai.post.presentation.response;
+
+import notai.post.application.result.PostSaveResult;
+
+public record PostSaveResponse(
+        Long id,
+        String title
+) {
+    public static PostSaveResponse from(PostSaveResult postSaveResult) {
+        return new PostSaveResponse(postSaveResult.id(), postSaveResult.title());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

> Post save 기능을 구현했습니다. 

## 💬 리뷰 요구사항 (선택)

1. response 값에 어떤걸 넣어주는게 포멀 한가요? 

- 게시글의 경우, 게시글 id 와 게시글 제목 정도만 반환해도 되나요? 아니면 게시글 내용도 반환하는게 좋나요 ? 
- 생성일자 안넣어도 되나요? 

2. document 보고+ gpt 내용 참고해서  ResponseEntity 에 새로생성된 게시글의 url 을 헤더에 넣어주는 방식으로 구현했는데, url fomat  생성하는 부분이 코드변경에 취약할 것 같아 보입니다. 이부분을 개선할 방법이 있나요? 아니면 이렇게 코드 작성하는게 잘못되었는지 궁금합니다. 

## 📸 이미지 첨부 (선택)
1. 현재는 게시글 id랑 title 정도만 반환하고 있습니다. 
![image](https://github.com/user-attachments/assets/b96178c2-f45a-4571-9b35-21623bf3e05e)

2. 이부분에서 v1, v2 가 추가된다거나 하는 url 이 변경된경우 , 일일이 찾아가서 수정하기 힘들어보입니다.  
![image](https://github.com/user-attachments/assets/f899e12e-5fc8-48dc-8aba-166f4296e95b)



## ➕ 이슈 링크

- [Feat:Post #6]https://github.com/kakao-tech-campus-2nd-step3/Team29_BE/issues/6
