### PR TITLE
Feat: 문서에 대한 회원의 소유 검증 추가, OCR, STT 기능 개선 및 버그 수정 (#78)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Team29_BE_Submodule"]
     path = Team29_BE_Submodule
     url = git@github.com:29ana-notai/Team29_BE_Submodule.git
-    branch = release/0.0.2
+    branch = release/0.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM gradle:jdk21-jammy
-
-WORKDIR /app
-
-CMD ["gradle", "bootRun"]

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'notai'
-version = '0.0.2'
+version = '0.0.3'
 
 java {
     toolchain {

--- a/src/main/java/notai/annotation/application/AnnotationQueryService.java
+++ b/src/main/java/notai/annotation/application/AnnotationQueryService.java
@@ -5,7 +5,9 @@ import notai.annotation.domain.Annotation;
 import notai.annotation.domain.AnnotationRepository;
 import notai.annotation.presentation.response.AnnotationResponse;
 import notai.common.exception.type.NotFoundException;
+import notai.document.domain.Document;
 import notai.document.domain.DocumentRepository;
+import notai.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +24,11 @@ public class AnnotationQueryService {
     private final DocumentRepository documentRepository;
 
     @Transactional(readOnly = true)
-    public List<AnnotationResponse> getAnnotationsByDocumentAndPageNumbers(Long documentId, List<Integer> pageNumbers) {
-        documentRepository.getById(documentId);
+    public List<AnnotationResponse> getAnnotationsByDocumentAndPageNumbers(
+            Member member, Long documentId, List<Integer> pageNumbers
+    ) {
+        Document document = documentRepository.getById(documentId);
+        document.validateOwner(member);
 
         List<Annotation> annotations = annotationRepository.findByDocumentIdAndPageNumberIn(documentId, pageNumbers);
         if (annotations.isEmpty()) {

--- a/src/main/java/notai/annotation/application/AnnotationService.java
+++ b/src/main/java/notai/annotation/application/AnnotationService.java
@@ -6,6 +6,7 @@ import notai.annotation.domain.AnnotationRepository;
 import notai.annotation.presentation.response.AnnotationResponse;
 import notai.document.domain.Document;
 import notai.document.domain.DocumentRepository;
+import notai.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,8 +18,11 @@ public class AnnotationService {
     private final DocumentRepository documentRepository;
 
     @Transactional
-    public AnnotationResponse createAnnotation(Long documentId, int pageNumber, int x, int y, int width, int height, String content) {
+    public AnnotationResponse createAnnotation(
+            Member member, Long documentId, int pageNumber, int x, int y, int width, int height, String content
+    ) {
         Document document = documentRepository.getById(documentId);
+        document.validateOwner(member);
 
         Annotation annotation = new Annotation(document, pageNumber, x, y, width, height, content);
         Annotation savedAnnotation = annotationRepository.save(annotation);
@@ -26,16 +30,20 @@ public class AnnotationService {
     }
 
     @Transactional
-    public AnnotationResponse updateAnnotation(Long documentId, Long annotationId, int x, int y, int width, int height, String content) {
-        documentRepository.getById(documentId);
+    public AnnotationResponse updateAnnotation(
+            Member member, Long documentId, Long annotationId, int x, int y, int width, int height, String content
+    ) {
+        Document document = documentRepository.getById(documentId);
+        document.validateOwner(member);
         Annotation annotation = annotationRepository.getById(annotationId);
         annotation.updateAnnotation(x, y, width, height, content);
         return AnnotationResponse.from(annotation);
     }
 
     @Transactional
-    public void deleteAnnotation(Long documentId, Long annotationId) {
-        documentRepository.getById(documentId);
+    public void deleteAnnotation(Member member, Long documentId, Long annotationId) {
+        Document document = documentRepository.getById(documentId);
+        document.validateOwner(member);
         Annotation annotation = annotationRepository.getById(annotationId);
         annotationRepository.delete(annotation);
     }

--- a/src/main/java/notai/annotation/presentation/AnnotationController.java
+++ b/src/main/java/notai/annotation/presentation/AnnotationController.java
@@ -6,6 +6,8 @@ import notai.annotation.application.AnnotationQueryService;
 import notai.annotation.application.AnnotationService;
 import notai.annotation.presentation.request.CreateAnnotationRequest;
 import notai.annotation.presentation.response.AnnotationResponse;
+import notai.auth.Auth;
+import notai.member.domain.Member;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,10 +24,12 @@ public class AnnotationController {
 
     @PostMapping
     public ResponseEntity<AnnotationResponse> createAnnotation(
-            @PathVariable Long documentId, @RequestBody @Valid CreateAnnotationRequest request
+            @Auth Member member, @PathVariable Long documentId, @RequestBody @Valid CreateAnnotationRequest request
     ) {
 
-        AnnotationResponse response = annotationService.createAnnotation(documentId,
+        AnnotationResponse response = annotationService.createAnnotation(
+                member,
+                documentId,
                 request.pageNumber(),
                 request.x(),
                 request.y(),
@@ -40,10 +44,11 @@ public class AnnotationController {
 
     @GetMapping
     public ResponseEntity<List<AnnotationResponse>> getAnnotations(
-            @PathVariable Long documentId, @RequestParam List<Integer> pageNumbers
+            @Auth Member member, @PathVariable Long documentId, @RequestParam List<Integer> pageNumbers
     ) {
 
         List<AnnotationResponse> response = annotationQueryService.getAnnotationsByDocumentAndPageNumbers(
+                member,
                 documentId,
                 pageNumbers
         );
@@ -53,12 +58,15 @@ public class AnnotationController {
 
     @PutMapping("/{annotationId}")
     public ResponseEntity<AnnotationResponse> updateAnnotation(
+            @Auth Member member,
             @PathVariable Long documentId,
             @PathVariable Long annotationId,
             @RequestBody @Valid CreateAnnotationRequest request
     ) {
 
-        AnnotationResponse response = annotationService.updateAnnotation(documentId,
+        AnnotationResponse response = annotationService.updateAnnotation(
+                member,
+                documentId,
                 annotationId,
                 request.x(),
                 request.y(),
@@ -72,10 +80,10 @@ public class AnnotationController {
 
     @DeleteMapping("/{annotationId}")
     public ResponseEntity<Void> deleteAnnotation(
-            @PathVariable Long documentId, @PathVariable Long annotationId
+            @Auth Member member, @PathVariable Long documentId, @PathVariable Long annotationId
     ) {
 
-        annotationService.deleteAnnotation(documentId, annotationId);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        annotationService.deleteAnnotation(member, documentId, annotationId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/notai/annotation/presentation/request/CreateAnnotationRequest.java
+++ b/src/main/java/notai/annotation/presentation/request/CreateAnnotationRequest.java
@@ -1,29 +1,29 @@
 package notai.annotation.presentation.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record CreateAnnotationRequest(
 
-        @Positive(message = "페이지 번호는 양수여야 합니다.")
+        @PositiveOrZero(message = "페이지 번호는 0 이상이어야 합니다.")
         int pageNumber,
 
-//        @Max(value = ?, message = "x 좌표는 최대 ? 이하여야 합니다.")
+        // @Max(value = ?, message = "x 좌표는 최대 ? 이하여야 합니다.")
         @PositiveOrZero(message = "x 좌표는 0 이상이어야 합니다.")
         int x,
 
-//        @Max(value = ?, message = "x 좌표는 최대 ? 이하여야 합니다.")
+        // @Max(value = ?, message = "x 좌표는 최대 ? 이하여야 합니다.")
         @PositiveOrZero(message = "y 좌표는 0 이상이어야 합니다.")
         int y,
 
-//        @Max(value = ?, message = "width는 최대 ? 이하여야 합니다.")
+        // @Max(value = ?, message = "width는 최대 ? 이하여야 합니다.")
         @Positive(message = "width는 양수여야 합니다.")
         int width,
 
-//        @Max(value = ?, message = "height는 최대 ? 이하여야 합니다.")
+        // @Max(value = ?, message = "height는 최대 ? 이하여야 합니다.")
         @Positive(message = "height는 양수여야 합니다.")
         int height,
 
         String content
-) {}
+) {
+}

--- a/src/main/java/notai/auth/AuthArgumentResolver.java
+++ b/src/main/java/notai/auth/AuthArgumentResolver.java
@@ -3,6 +3,7 @@ package notai.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import notai.member.domain.Member;
 import notai.member.domain.MemberRepository;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -23,7 +24,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Long resolveArgument(
+    public Member resolveArgument(
             MethodParameter parameter,
             ModelAndViewContainer mavContainer,
             NativeWebRequest webRequest,
@@ -31,6 +32,6 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         Long memberId = (Long) request.getAttribute("memberId");
-        return memberRepository.getById(memberId).getId();
+        return memberRepository.getById(memberId);
     }
 }

--- a/src/main/java/notai/client/ai/AiClient.java
+++ b/src/main/java/notai/client/ai/AiClient.java
@@ -2,11 +2,11 @@ package notai.client.ai;
 
 import notai.client.ai.request.LlmTaskRequest;
 import notai.client.ai.response.TaskResponse;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.service.annotation.PostExchange;
-
-import java.io.InputStream;
 
 public interface AiClient {
 
@@ -14,5 +14,5 @@ public interface AiClient {
     TaskResponse submitLlmTask(@RequestBody LlmTaskRequest request);
 
     @PostExchange(url = "/api/ai/stt", contentType = MediaType.MULTIPART_FORM_DATA_VALUE)
-    TaskResponse submitSttTask(@RequestBody InputStream audioFileStream);
+    TaskResponse submitSttTask(@RequestPart("audio") ByteArrayResource audioFile);
 }

--- a/src/main/java/notai/client/ai/AiClientConfig.java
+++ b/src/main/java/notai/client/ai/AiClientConfig.java
@@ -6,7 +6,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
 
 import static notai.client.HttpInterfaceUtil.createHttpInterface;
 import static notai.common.exception.ErrorMessages.AI_SERVER_ERROR;
@@ -20,15 +23,26 @@ public class AiClientConfig {
 
     @Bean
     public AiClient aiClient() {
-        RestClient restClient =
-                RestClient.builder().baseUrl(aiServerUrl).requestInterceptor((request, body, execution) -> {
-                    request.getHeaders().setContentLength(body.length); // Content-Length 설정 안하면 411 에러 발생
-                    return execution.execute(request, body);
-                }).defaultStatusHandler(HttpStatusCode::isError, (request, response) -> {
-                    String responseBody = new String(response.getBody().readAllBytes());
-                    log.error("Response Status: {}", response.getStatusCode());
-                    throw new ExternalApiException(AI_SERVER_ERROR, response.getStatusCode().value());
-                }).build();
+        RestClient restClient = RestClient.builder()
+            .baseUrl(aiServerUrl)
+            .messageConverters(converters -> {
+                converters.addAll(new RestTemplate().getMessageConverters());
+                converters.add(new FormHttpMessageConverter());
+            })
+            .requestInterceptor((request, body, execution) -> {
+                request.getHeaders().setContentLength(body.length); // Content-Length 설정 안하면 411 에러 발생
+                return execution.execute(request, body);
+            })
+            .defaultStatusHandler(HttpStatusCode::isError, (request, response) -> {
+                String responseBody = new String(response.getBody().readAllBytes());
+                log.error("AI 서버에서 오류가 발생했습니다. - Status: {}, Body: {}",
+                    response.getStatusCode(), 
+                    responseBody
+                );
+                throw new ExternalApiException(AI_SERVER_ERROR, response.getStatusCode().value());
+            })
+            .build();
+
         return createHttpInterface(restClient, AiClient.class);
     }
 }

--- a/src/main/java/notai/common/config/AuthConfig.java
+++ b/src/main/java/notai/common/config/AuthConfig.java
@@ -17,8 +17,12 @@ public class AuthConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authInterceptor).addPathPatterns("/api/**").excludePathPatterns(
-                "/api/members/oauth/login/**").excludePathPatterns("/api/members/token/refresh");
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/members/oauth/login/**")
+                .excludePathPatterns("/api/members/token/refresh")
+                .excludePathPatterns("/api/ai/stt/callback")
+                .excludePathPatterns("/api/ai/llm/callback");
     }
 
     @Override

--- a/src/main/java/notai/common/config/SwaggerConfig.java
+++ b/src/main/java/notai/common/config/SwaggerConfig.java
@@ -38,6 +38,6 @@ public class SwaggerConfig {
     }
 
     private Info apiInfo() {
-        return new Info().title("notai API").description("notai API 문서입니다.").version("0.0.2");
+        return new Info().title("notai API").description("notai API 문서입니다.").version("0.0.3");
     }
 }

--- a/src/main/java/notai/common/domain/vo/FilePath.java
+++ b/src/main/java/notai/common/domain/vo/FilePath.java
@@ -14,7 +14,7 @@ import static notai.common.exception.ErrorMessages.INVALID_FILE_TYPE;
 @NoArgsConstructor(access = PROTECTED)
 public class FilePath {
 
-    @Column(length = 50)
+    @Column(length = 255)
     private String filePath;
 
     private FilePath(String filePath) {
@@ -22,11 +22,6 @@ public class FilePath {
     }
 
     public static FilePath from(String filePath) {
-        // 추후 확장자 추가
-        if (!filePath.matches(
-                "[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣()\\[\\]+\\-&/_\\s]+(/[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣()\\[\\]+\\-&/_\\s]+)*/?[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣()\\[\\]+\\-&/_\\s]+\\.mp3")) {
-            throw new BadRequestException(INVALID_FILE_TYPE);
-        }
         return new FilePath(filePath);
     }
 }

--- a/src/main/java/notai/common/exception/type/BadRequestException.java
+++ b/src/main/java/notai/common/exception/type/BadRequestException.java
@@ -9,4 +9,7 @@ public class BadRequestException extends ApplicationException {
     public BadRequestException(ErrorMessages message) {
         super(message, 400);
     }
+    public BadRequestException(String message) {
+        super(message, 400);
+    }
 }

--- a/src/main/java/notai/document/application/DocumentQueryService.java
+++ b/src/main/java/notai/document/application/DocumentQueryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import notai.document.application.result.DocumentFindResult;
 import notai.document.domain.Document;
 import notai.document.domain.DocumentRepository;
+import notai.member.domain.Member;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -19,8 +20,8 @@ public class DocumentQueryService {
         return documents.stream().map(this::getDocumentFindResult).toList();
     }
 
-    public List<DocumentFindResult> findRootDocuments(Long memberId) {
-        List<Document> documents = documentRepository.findAllByMemberIdAndFolderIdIsNull(memberId);
+    public List<DocumentFindResult> findRootDocuments(Member member) {
+        List<Document> documents = documentRepository.findAllByMemberIdAndFolderIdIsNull(member.getId());
         return documents.stream().map(this::getDocumentFindResult).toList();
     }
 

--- a/src/main/java/notai/document/presentation/DocumentController.java
+++ b/src/main/java/notai/document/presentation/DocumentController.java
@@ -1,5 +1,7 @@
 package notai.document.presentation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import lombok.RequiredArgsConstructor;
 import notai.auth.Auth;
 import notai.document.application.DocumentQueryService;
@@ -12,6 +14,8 @@ import notai.document.presentation.request.DocumentUpdateRequest;
 import notai.document.presentation.response.DocumentFindResponse;
 import notai.document.presentation.response.DocumentSaveResponse;
 import notai.document.presentation.response.DocumentUpdateResponse;
+import notai.member.domain.Member;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,19 +34,20 @@ public class DocumentController {
     private static final Long ROOT_FOLDER_ID = -1L;
     private static final String FOLDER_URL_FORMAT = "/api/folders/%s/documents/%s";
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<DocumentSaveResponse> saveDocument(
-            @Auth Long memberId,
+            @Auth Member member,
             @PathVariable Long folderId,
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_PDF_VALUE))
             @RequestPart MultipartFile pdfFile,
             @RequestPart DocumentSaveRequest documentSaveRequest
     ) {
 
         DocumentSaveResult documentSaveResult;
         if (folderId.equals(ROOT_FOLDER_ID)) {
-            documentSaveResult = documentService.saveRootDocument(memberId, pdfFile, documentSaveRequest);
+            documentSaveResult = documentService.saveRootDocument(member, pdfFile, documentSaveRequest);
         } else {
-            documentSaveResult = documentService.saveDocument(memberId, folderId, pdfFile, documentSaveRequest);
+            documentSaveResult = documentService.saveDocument(member, folderId, pdfFile, documentSaveRequest);
         }
         DocumentSaveResponse response = DocumentSaveResponse.from(documentSaveResult);
         String url = String.format(FOLDER_URL_FORMAT, folderId, response.id());
@@ -51,13 +56,13 @@ public class DocumentController {
 
     @PutMapping(value = "/{id}")
     public ResponseEntity<DocumentUpdateResponse> updateDocument(
-            @Auth Long memberId,
+            @Auth Member member,
             @PathVariable Long folderId,
             @PathVariable Long id,
             @RequestBody DocumentUpdateRequest documentUpdateRequest
     ) {
         DocumentUpdateResult documentUpdateResult = documentService.updateDocument(
-                memberId,
+                member,
                 folderId,
                 id,
                 documentUpdateRequest
@@ -68,11 +73,11 @@ public class DocumentController {
 
     @GetMapping
     public ResponseEntity<List<DocumentFindResponse>> getDocuments(
-            @Auth Long memberId, @PathVariable Long folderId
+            @Auth Member member, @PathVariable Long folderId
     ) {
         List<DocumentFindResult> documentResults;
         if (folderId.equals(ROOT_FOLDER_ID)) {
-            documentResults = documentQueryService.findRootDocuments(memberId);
+            documentResults = documentQueryService.findRootDocuments(member);
         } else {
             documentResults = documentQueryService.findDocuments(folderId);
         }
@@ -83,9 +88,9 @@ public class DocumentController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteDocument(
-            @Auth Long memberId, @PathVariable Long folderId, @PathVariable Long id
+            @Auth Member member, @PathVariable Long folderId, @PathVariable Long id
     ) {
-        documentService.deleteDocument(memberId, folderId, id);
+        documentService.deleteDocument(member, folderId, id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/notai/folder/application/FolderQueryService.java
+++ b/src/main/java/notai/folder/application/FolderQueryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import notai.folder.application.result.FolderFindResult;
 import notai.folder.domain.Folder;
 import notai.folder.domain.FolderRepository;
+import notai.member.domain.Member;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -14,17 +15,17 @@ public class FolderQueryService {
 
     private final FolderRepository folderRepository;
 
-    public List<FolderFindResult> getFolders(Long memberId, Long parentFolderId) {
-        List<Folder> folders = getFoldersWithMemberAndParent(memberId, parentFolderId);
+    public List<FolderFindResult> getFolders(Member member, Long parentFolderId) {
+        List<Folder> folders = getFoldersWithMemberAndParent(member, parentFolderId);
         // document read
         return folders.stream().map(this::getFolderResult).toList();
     }
 
-    private List<Folder> getFoldersWithMemberAndParent(Long memberId, Long parentFolderId) {
+    private List<Folder> getFoldersWithMemberAndParent(Member member, Long parentFolderId) {
         if (parentFolderId == null) {
-            return folderRepository.findAllByMemberIdAndParentFolderIsNull(memberId);
+            return folderRepository.findAllByMemberIdAndParentFolderIsNull(member.getId());
         }
-        return folderRepository.findAllByMemberIdAndParentFolderId(memberId, parentFolderId);
+        return folderRepository.findAllByMemberIdAndParentFolderId(member.getId(), parentFolderId);
     }
 
     private FolderFindResult getFolderResult(Folder folder) {

--- a/src/main/java/notai/folder/application/FolderService.java
+++ b/src/main/java/notai/folder/application/FolderService.java
@@ -11,7 +11,6 @@ import notai.folder.presentation.request.FolderMoveRequest;
 import notai.folder.presentation.request.FolderSaveRequest;
 import notai.folder.presentation.request.FolderUpdateRequest;
 import notai.member.domain.Member;
-import notai.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,57 +20,54 @@ import java.util.List;
 public class FolderService {
 
     private final FolderRepository folderRepository;
-    private final MemberRepository memberRepository;
     private final DocumentService documentService;
 
-    public FolderSaveResult saveRootFolder(Long memberId, FolderSaveRequest folderSaveRequest) {
-        Member member = memberRepository.getById(memberId);
+    public FolderSaveResult saveRootFolder(Member member, FolderSaveRequest folderSaveRequest) {
         Folder folder = new Folder(member, folderSaveRequest.name());
         Folder savedFolder = folderRepository.save(folder);
         return getFolderSaveResult(savedFolder);
     }
 
-    public FolderSaveResult saveSubFolder(Long memberId, FolderSaveRequest folderSaveRequest) {
-        Member member = memberRepository.getById(memberId);
+    public FolderSaveResult saveSubFolder(Member member, FolderSaveRequest folderSaveRequest) {
         Folder parentFolder = folderRepository.getById(folderSaveRequest.parentFolderId());
         Folder folder = new Folder(member, folderSaveRequest.name(), parentFolder);
         Folder savedFolder = folderRepository.save(folder);
         return getFolderSaveResult(savedFolder);
     }
 
-    public FolderMoveResult moveRootFolder(Long memberId, Long id) {
+    public FolderMoveResult moveRootFolder(Member member, Long id) {
         Folder folder = folderRepository.getById(id);
-        folder.validateOwner(memberId);
+        folder.validateOwner(member);
         folder.moveRootFolder();
         folderRepository.save(folder);
         return getFolderMoveResult(folder);
     }
 
-    public FolderMoveResult moveNewParentFolder(Long memberId, Long id, FolderMoveRequest folderMoveRequest) {
+    public FolderMoveResult moveNewParentFolder(Member member, Long id, FolderMoveRequest folderMoveRequest) {
         Folder folder = folderRepository.getById(id);
         Folder parentFolder = folderRepository.getById(folderMoveRequest.targetFolderId());
-        folder.validateOwner(memberId);
+        folder.validateOwner(member);
         folder.moveNewParentFolder(parentFolder);
         folderRepository.save(folder);
         return getFolderMoveResult(folder);
     }
 
-    public FolderUpdateResult updateFolder(Long memberId, Long id, FolderUpdateRequest folderUpdateRequest) {
+    public FolderUpdateResult updateFolder(Member member, Long id, FolderUpdateRequest folderUpdateRequest) {
         Folder folder = folderRepository.getById(id);
-        folder.validateOwner(memberId);
+        folder.validateOwner(member);
         folder.updateName(folderUpdateRequest.name());
         folderRepository.save(folder);
         return getFolderUpdateResult(folder);
     }
 
-    public void deleteFolder(Long memberId, Long id) {
+    public void deleteFolder(Member member, Long id) {
         Folder folder = folderRepository.getById(id);
-        folder.validateOwner(memberId);
+        folder.validateOwner(member);
         List<Folder> subFolders = folderRepository.findAllByParentFolder(folder);
         for (Folder subFolder : subFolders) {
-            deleteFolder(memberId, subFolder.getId());
+            deleteFolder(member, subFolder.getId());
         }
-        documentService.deleteAllByFolder(memberId, folder);
+        documentService.deleteAllByFolder(member, folder);
         folderRepository.delete(folder);
     }
 

--- a/src/main/java/notai/folder/domain/Folder.java
+++ b/src/main/java/notai/folder/domain/Folder.java
@@ -59,8 +59,8 @@ public class Folder extends RootEntity<Long> {
         this.parentFolder = parentFolder;
     }
 
-    public void validateOwner(Long memberId) {
-        if (!this.member.getId().equals(memberId)) {
+    public void validateOwner(Member member) {
+        if (!this.member.getId().equals(member.getId())) {
             log.info("폴더 소유자가 요청 사용자와 다릅니다.");
             throw new NotFoundException(FOLDER_NOT_FOUND);
         }

--- a/src/main/java/notai/folder/presentation/FolderController.java
+++ b/src/main/java/notai/folder/presentation/FolderController.java
@@ -16,6 +16,7 @@ import notai.folder.presentation.response.FolderFindResponse;
 import notai.folder.presentation.response.FolderMoveResponse;
 import notai.folder.presentation.response.FolderSaveResponse;
 import notai.folder.presentation.response.FolderUpdateResponse;
+import notai.member.domain.Member;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,59 +33,59 @@ public class FolderController {
 
     @PostMapping
     public ResponseEntity<FolderSaveResponse> saveFolder(
-            @Auth Long memberId, @Valid @RequestBody FolderSaveRequest folderSaveRequest
+            @Auth Member member, @Valid @RequestBody FolderSaveRequest folderSaveRequest
     ) {
-        FolderSaveResult folderResult = saveFolderResult(memberId, folderSaveRequest);
+        FolderSaveResult folderResult = saveFolderResult(member, folderSaveRequest);
         FolderSaveResponse response = FolderSaveResponse.from(folderResult);
         return ResponseEntity.created(URI.create("/api/folders/" + response.id())).body(response);
     }
 
     @PostMapping("/{id}/move")
     public ResponseEntity<FolderMoveResponse> moveFolder(
-            @Auth Long memberId, @PathVariable Long id, @Valid @RequestBody FolderMoveRequest folderMoveRequest
+            @Auth Member member, @PathVariable Long id, @Valid @RequestBody FolderMoveRequest folderMoveRequest
     ) {
-        FolderMoveResult folderResult = moveFolderWithRequest(memberId, id, folderMoveRequest);
+        FolderMoveResult folderResult = moveFolderWithRequest(member, id, folderMoveRequest);
         FolderMoveResponse response = FolderMoveResponse.from(folderResult);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<FolderUpdateResponse> updateFolder(
-            @Auth Long memberId, @PathVariable Long id, @Valid @RequestBody FolderUpdateRequest folderUpdateRequest
+            @Auth Member member, @PathVariable Long id, @Valid @RequestBody FolderUpdateRequest folderUpdateRequest
     ) {
-        FolderUpdateResult folderResult = folderService.updateFolder(memberId, id, folderUpdateRequest);
+        FolderUpdateResult folderResult = folderService.updateFolder(member, id, folderUpdateRequest);
         FolderUpdateResponse response = FolderUpdateResponse.from(folderResult);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping
     public ResponseEntity<List<FolderFindResponse>> getFolders(
-            @Auth Long memberId, @RequestParam(required = false) Long parentFolderId
+            @Auth Member member, @RequestParam(required = false) Long parentFolderId
     ) {
-        List<FolderFindResult> folderResults = folderQueryService.getFolders(memberId, parentFolderId);
+        List<FolderFindResult> folderResults = folderQueryService.getFolders(member, parentFolderId);
         List<FolderFindResponse> response = folderResults.stream().map(FolderFindResponse::from).toList();
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteFolder(
-            @Auth Long memberId, @PathVariable Long id
+            @Auth Member member, @PathVariable Long id
     ) {
-        folderService.deleteFolder(memberId, id);
+        folderService.deleteFolder(member, id);
         return ResponseEntity.noContent().build();
     }
 
-    private FolderSaveResult saveFolderResult(Long memberId, FolderSaveRequest folderSaveRequest) {
+    private FolderSaveResult saveFolderResult(Member member, FolderSaveRequest folderSaveRequest) {
         if (folderSaveRequest.parentFolderId() != null) {
-            return folderService.saveSubFolder(memberId, folderSaveRequest);
+            return folderService.saveSubFolder(member, folderSaveRequest);
         }
-        return folderService.saveRootFolder(memberId, folderSaveRequest);
+        return folderService.saveRootFolder(member, folderSaveRequest);
     }
 
-    private FolderMoveResult moveFolderWithRequest(Long memberId, Long id, FolderMoveRequest folderMoveRequest) {
+    private FolderMoveResult moveFolderWithRequest(Member member, Long id, FolderMoveRequest folderMoveRequest) {
         if (folderMoveRequest.targetFolderId() != null) {
-            return folderService.moveNewParentFolder(memberId, id, folderMoveRequest);
+            return folderService.moveNewParentFolder(member, id, folderMoveRequest);
         }
-        return folderService.moveRootFolder(memberId, id);
+        return folderService.moveRootFolder(member, id);
     }
 }

--- a/src/main/java/notai/llm/application/LlmTaskService.java
+++ b/src/main/java/notai/llm/application/LlmTaskService.java
@@ -73,6 +73,8 @@ public class LlmTaskService {
         if (foundSummary.isEmpty() && foundProblem.isEmpty()) {
             Summary summary = new Summary(foundDocument, pageNumber);
             Problem problem = new Problem(foundDocument, pageNumber);
+            summaryRepository.save(summary);
+            problemRepository.save(problem);
 
             LlmTask taskRecord = new LlmTask(taskId, summary, problem);
             llmTaskRepository.save(taskRecord);
@@ -80,6 +82,7 @@ public class LlmTaskService {
         if (foundSummary.isPresent() && foundProblem.isPresent()) {
             LlmTask foundTaskRecord = llmTaskRepository.getBySummaryAndProblem(foundSummary.get(), foundProblem.get());
             llmTaskRepository.delete(foundTaskRecord);
+            llmTaskRepository.flush();
 
             LlmTask taskRecord = new LlmTask(taskId, foundSummary.get(), foundProblem.get());
             llmTaskRepository.save(taskRecord);

--- a/src/main/java/notai/llm/domain/LlmTask.java
+++ b/src/main/java/notai/llm/domain/LlmTask.java
@@ -25,12 +25,12 @@ public class LlmTask extends RootEntity<UUID> {
     private UUID id;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "summary_id")
     private Summary summary;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id")
     private Problem problem;
 

--- a/src/main/java/notai/llm/presentation/LlmTaskController.java
+++ b/src/main/java/notai/llm/presentation/LlmTaskController.java
@@ -2,6 +2,7 @@ package notai.llm.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import notai.auth.Auth;
 import notai.llm.application.LlmTaskQueryService;
 import notai.llm.application.LlmTaskService;
 import notai.llm.application.command.LlmTaskPageResultCommand;
@@ -12,6 +13,7 @@ import notai.llm.application.result.*;
 import notai.llm.presentation.request.LlmTaskSubmitRequest;
 import notai.llm.presentation.request.SummaryAndProblemUpdateRequest;
 import notai.llm.presentation.response.*;
+import notai.member.domain.Member;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,31 +33,40 @@ public class LlmTaskController {
     }
 
     @GetMapping("/status/{documentId}")
-    public ResponseEntity<LlmTaskOverallStatusResponse> fetchOverallStatus(@PathVariable("documentId") Long documentId) {
-        LlmTaskOverallStatusResult result = llmTaskQueryService.fetchOverallStatus(documentId);
+    public ResponseEntity<LlmTaskOverallStatusResponse> fetchOverallStatus(
+            @Auth Member member, @PathVariable("documentId") Long documentId
+    ) {
+        LlmTaskOverallStatusResult result = llmTaskQueryService.fetchOverallStatus(member, documentId);
         return ResponseEntity.ok(LlmTaskOverallStatusResponse.from(result));
     }
 
     @GetMapping("/status/{documentId}/{pageNumber}")
     public ResponseEntity<LlmTaskPageStatusResponse> fetchPageStatus(
-            @PathVariable("documentId") Long documentId, @PathVariable("pageNumber") Integer pageNumber
+            @Auth Member member,
+            @PathVariable("documentId") Long documentId,
+            @PathVariable("pageNumber") Integer pageNumber
     ) {
         LlmTaskPageStatusCommand command = LlmTaskPageStatusCommand.of(documentId, pageNumber);
-        LlmTaskPageStatusResult result = llmTaskQueryService.fetchPageStatus(command);
+        LlmTaskPageStatusResult result = llmTaskQueryService.fetchPageStatus(member, command);
         return ResponseEntity.ok(LlmTaskPageStatusResponse.from(result));
     }
 
     @GetMapping("/results/{documentId}")
-    public ResponseEntity<LlmTaskAllPagesResultResponse> findAllPagesResult(@PathVariable("documentId") Long documentId) {
-        LlmTaskAllPagesResult result = llmTaskQueryService.findAllPagesResult(documentId);
+    public ResponseEntity<LlmTaskAllPagesResultResponse> findAllPagesResult(
+            @Auth Member member, @PathVariable("documentId") Long documentId
+    ) {
+        LlmTaskAllPagesResult result = llmTaskQueryService.findAllPagesResult(member, documentId);
         return ResponseEntity.ok(LlmTaskAllPagesResultResponse.from(result));
     }
 
     @GetMapping("/results/{documentId}/{pageNumber}")
     public ResponseEntity<LlmTaskPageResultResponse> findPageResult(
-            @PathVariable("documentId") Long documentId, @PathVariable("pageNumber") Integer pageNumber) {
+            @Auth Member member,
+            @PathVariable("documentId") Long documentId,
+            @PathVariable("pageNumber") Integer pageNumber
+    ) {
         LlmTaskPageResultCommand command = LlmTaskPageResultCommand.of(documentId, pageNumber);
-        LlmTaskPageResult result = llmTaskQueryService.findPageResult(command);
+        LlmTaskPageResult result = llmTaskQueryService.findPageResult(member, command);
         return ResponseEntity.ok(LlmTaskPageResultResponse.from(result));
     }
 

--- a/src/main/java/notai/llm/presentation/request/LlmTaskSubmitRequest.java
+++ b/src/main/java/notai/llm/presentation/request/LlmTaskSubmitRequest.java
@@ -1,7 +1,7 @@
 package notai.llm.presentation.request;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import notai.llm.application.command.LlmTaskSubmitCommand;
 
 import java.util.List;
@@ -10,7 +10,7 @@ public record LlmTaskSubmitRequest(
 
         @NotNull(message = "문서 ID는 필수 입력 값입니다.") Long documentId,
 
-        List<@Positive(message = "페이지 번호는 양수여야 합니다.") Integer> pages
+        List<@PositiveOrZero(message = "페이지 번호는 음수일 수 없습니다.") Integer> pages
 ) {
     public LlmTaskSubmitCommand toCommand() {
         return new LlmTaskSubmitCommand(documentId, pages);

--- a/src/main/java/notai/ocr/application/OCRQueryService.java
+++ b/src/main/java/notai/ocr/application/OCRQueryService.java
@@ -1,12 +1,14 @@
 package notai.ocr.application;
 
 import lombok.RequiredArgsConstructor;
-import static notai.common.exception.ErrorMessages.OCR_RESULT_NOT_FOUND;
 import notai.common.exception.type.NotFoundException;
+import notai.member.domain.Member;
 import notai.ocr.application.result.OCRFindResult;
 import notai.ocr.domain.OCR;
 import notai.ocr.domain.OCRRepository;
 import org.springframework.stereotype.Service;
+
+import static notai.common.exception.ErrorMessages.OCR_RESULT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +16,10 @@ public class OCRQueryService {
 
     private final OCRRepository ocrRepository;
 
-    public OCRFindResult findOCR(Long documentId, Integer pageNumber) {
-        OCR ocr = ocrRepository.findOCRByDocumentIdAndPageNumber(documentId,
-                pageNumber
+    public OCRFindResult findOCR(Member member, Long documentId, Integer pageNumber) {
+        OCR ocr = ocrRepository.findOCRByDocumentIdAndPageNumber(documentId, pageNumber
         ).orElseThrow(() -> new NotFoundException(OCR_RESULT_NOT_FOUND));
+        ocr.getDocument().validateOwner(member);
 
         return OCRFindResult.of(documentId, pageNumber, ocr.getContent());
     }

--- a/src/main/java/notai/ocr/domain/OCR.java
+++ b/src/main/java/notai/ocr/domain/OCR.java
@@ -28,7 +28,7 @@ public class OCR extends RootEntity<Long> {
     private Integer pageNumber;
 
     @NotNull
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "content", columnDefinition = "LONGTEXT")
     private String content;
 
     public OCR(Document document, Integer pageNumber, String content) {

--- a/src/main/java/notai/ocr/presentation/OCRController.java
+++ b/src/main/java/notai/ocr/presentation/OCRController.java
@@ -1,6 +1,8 @@
 package notai.ocr.presentation;
 
 import lombok.RequiredArgsConstructor;
+import notai.auth.Auth;
+import notai.member.domain.Member;
 import notai.ocr.application.OCRQueryService;
 import notai.ocr.application.result.OCRFindResult;
 import notai.ocr.presentation.response.OCRFindResponse;
@@ -16,9 +18,9 @@ public class OCRController {
 
     @GetMapping
     public ResponseEntity<OCRFindResponse> getDocuments(
-            @PathVariable Long documentId, @RequestParam Integer pageNumber
+            @Auth Member member, @PathVariable Long documentId, @RequestParam Integer pageNumber
     ) {
-        OCRFindResult result = ocrQueryService.findOCR(documentId, pageNumber);
+        OCRFindResult result = ocrQueryService.findOCR(member, documentId, pageNumber);
         OCRFindResponse response = OCRFindResponse.from(result);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/notai/pageRecording/domain/PageRecording.java
+++ b/src/main/java/notai/pageRecording/domain/PageRecording.java
@@ -31,7 +31,6 @@ public class PageRecording {
     @NotNull
     private Double startTime;
 
-    @NotNull
     private Double endTime;
 
     public PageRecording(Recording recording, Integer pageNumber, Double startTime, Double endTime) {

--- a/src/main/java/notai/pageRecording/presentation/PageRecordingController.java
+++ b/src/main/java/notai/pageRecording/presentation/PageRecordingController.java
@@ -1,17 +1,15 @@
 package notai.pageRecording.presentation;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
 import lombok.RequiredArgsConstructor;
+import notai.auth.Auth;
+import notai.member.domain.Member;
 import notai.pageRecording.application.PageRecordingService;
 import notai.pageRecording.application.command.PageRecordingSaveCommand;
 import notai.pageRecording.presentation.request.PageRecordingSaveRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequestMapping("/api/documents/{documentId}/recordings/page-turns")
@@ -22,10 +20,12 @@ public class PageRecordingController {
 
     @PostMapping
     public ResponseEntity<Void> savePageRecording(
-            @PathVariable("documentId") Long documentId, @RequestBody PageRecordingSaveRequest request
+            @Auth Member member,
+            @PathVariable("documentId") Long documentId,
+            @RequestBody PageRecordingSaveRequest request
     ) {
         PageRecordingSaveCommand command = request.toCommand(documentId);
-        pageRecordingService.savePageRecording(command);
+        pageRecordingService.savePageRecording(member, command);
         return ResponseEntity.status(CREATED).build();
     }
 }

--- a/src/main/java/notai/recording/application/RecordingService.java
+++ b/src/main/java/notai/recording/application/RecordingService.java
@@ -10,6 +10,7 @@ import notai.common.utils.AudioDecoder;
 import notai.common.utils.FileManager;
 import notai.document.domain.Document;
 import notai.document.domain.DocumentRepository;
+import notai.member.domain.Member;
 import notai.recording.application.command.RecordingSaveCommand;
 import notai.recording.application.result.RecordingSaveResult;
 import notai.recording.domain.Recording;
@@ -38,8 +39,9 @@ public class RecordingService {
     @Value("${file.audio.basePath}")
     private String audioBasePath;
 
-    public RecordingSaveResult saveRecording(RecordingSaveCommand command) {
+    public RecordingSaveResult saveRecording(Member member, RecordingSaveCommand command) {
         Document foundDocument = documentRepository.getById(command.documentId());
+        foundDocument.validateOwner(member);
 
         Recording recording = new Recording(foundDocument);
         Recording savedRecording = recordingRepository.save(recording);
@@ -60,7 +62,7 @@ public class RecordingService {
             return RecordingSaveResult.of(savedRecording.getId(), foundDocument.getId(), savedRecording.getCreatedAt());
 
         } catch (IllegalArgumentException e) {
-            throw new BadRequestException(INVALID_AUDIO_ENCODING);
+            throw new BadRequestException(INVALID_AUDIO_ENCODING + " : " + e.getMessage());
         } catch (IOException e) {
             throw new InternalServerErrorException(FILE_SAVE_ERROR); // TODO: 재시도 로직 추가?
         }

--- a/src/main/java/notai/recording/domain/Recording.java
+++ b/src/main/java/notai/recording/domain/Recording.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import notai.common.domain.RootEntity;
 import notai.common.domain.vo.FilePath;
+import notai.common.exception.type.NotFoundException;
 import notai.document.domain.Document;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
+import static notai.common.exception.ErrorMessages.RECORDING_NOT_FOUND;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -37,7 +39,9 @@ public class Recording extends RootEntity<Long> {
         this.filePath = filePath;
     }
 
-    public boolean isRecordingOwnedByDocument(Long documentId) {
-        return this.document.getId().equals(documentId);
+    public void validateDocumentOwnership(Document document) {
+        if (this.document.getId().equals(document.getId())) {
+            throw new NotFoundException(RECORDING_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/notai/recording/presentation/RecordingController.java
+++ b/src/main/java/notai/recording/presentation/RecordingController.java
@@ -1,20 +1,18 @@
 package notai.recording.presentation;
 
-import static org.springframework.http.HttpStatus.CREATED;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import notai.auth.Auth;
+import notai.member.domain.Member;
 import notai.recording.application.RecordingService;
 import notai.recording.application.command.RecordingSaveCommand;
 import notai.recording.application.result.RecordingSaveResult;
 import notai.recording.presentation.request.RecordingSaveRequest;
 import notai.recording.presentation.response.RecordingSaveResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequestMapping("/api/documents/{documentId}/recordings")
@@ -25,10 +23,12 @@ public class RecordingController {
 
     @PostMapping
     public ResponseEntity<RecordingSaveResponse> saveRecording(
-            @PathVariable("documentId") Long documentId, @RequestBody @Valid RecordingSaveRequest request
+            @Auth Member member,
+            @PathVariable("documentId") Long documentId,
+            @RequestBody @Valid RecordingSaveRequest request
     ) {
         RecordingSaveCommand command = request.toCommand(documentId);
-        RecordingSaveResult result = recordingService.saveRecording(command);
+        RecordingSaveResult result = recordingService.saveRecording(member, command);
         return ResponseEntity.status(CREATED).body(RecordingSaveResponse.from(result));
     }
 }

--- a/src/main/java/notai/stt/application/SttService.java
+++ b/src/main/java/notai/stt/application/SttService.java
@@ -33,6 +33,7 @@ public class SttService {
         SttTask sttTask = sttTaskRepository.getById(command.taskId());
         Stt stt = sttTask.getStt();
         Recording recording = stt.getRecording();
+
         List<PageRecording> pageRecordings = pageRecordingRepository.findAllByRecordingIdOrderByStartTime(recording.getId());
 
         SttPageMatchedDto matchedResult = stt.matchWordsWithPages(command.words(), pageRecordings);

--- a/src/main/java/notai/stt/domain/Stt.java
+++ b/src/main/java/notai/stt/domain/Stt.java
@@ -92,7 +92,7 @@ public class Stt extends RootEntity<Long> {
         for (PageRecording page : pageRecordings) {
             List<SttPageMatchedDto.PageMatchedWord> pageWords = new ArrayList<>();
             double pageStart = page.getStartTime();
-            double pageEnd = page.getEndTime();
+            Double pageEnd = page.getEndTime();
 
             // 현재 페이지의 시간 범위에 속하는 단어들을 찾아 매칭
             while (wordIndex < words.size()) {
@@ -104,18 +104,17 @@ public class Stt extends RootEntity<Long> {
                     continue;
                 }
 
-                // 마지막 페이지가 아닐 경우, 페이지 종료 시간을 벗어난 단어가 나오면 다음 페이지로
-                if (page != lastPage && word.start() - TIME_THRESHOLD >= pageEnd) {
+                // 마지막 페이지이거나 endTime이 null이면 시작 시간만 체크
+                if ((page == lastPage || pageEnd == null) || word.start() - TIME_THRESHOLD < pageEnd) {
+                    pageWords.add(new SttPageMatchedDto.PageMatchedWord(
+                            word.word(),
+                            (int) word.start(),
+                            (int) word.end()
+                    ));
+                    wordIndex++;
+                } else {
                     break;
                 }
-
-                // 현재 페이지에 단어 매칭하여 추가
-                pageWords.add(new SttPageMatchedDto.PageMatchedWord(
-                        word.word(),
-                        (int) word.start(),
-                        (int) word.end()
-                ));
-                wordIndex++;
             }
 
             // 매칭된 단어가 있는 경우만 맵에 추가

--- a/src/main/java/notai/stt/presentation/request/SttCallbackRequest.java
+++ b/src/main/java/notai/stt/presentation/request/SttCallbackRequest.java
@@ -1,38 +1,29 @@
 package notai.stt.presentation.request;
 
 import notai.stt.application.command.UpdateSttResultCommand;
-import notai.stt.application.command.UpdateSttResultCommand.Word;
 
 import java.util.List;
 import java.util.UUID;
 
 public record SttCallbackRequest(
         String taskId,
-        String state,
-        SttResult result
+        String text,
+        List<Word> words
 ) {
     public UpdateSttResultCommand toCommand() {
-        List<Word> words = result.words().stream()
-                .map(word -> new Word(
+        List<UpdateSttResultCommand.Word> commandWords = words().stream()
+                .map(word -> new UpdateSttResultCommand.Word(
                         word.word(),
                         word.start(),
-                        word.end()
-                ))
+                        word.end()))
                 .toList();
-        return new UpdateSttResultCommand(UUID.fromString(taskId), words);
+        return new UpdateSttResultCommand(UUID.fromString(taskId), commandWords);
     }
-
-    public record SttResult(
-            double audioLength,
-            String language,
-            double languageProbability,
-            String text,
-            List<Word> words
+    
+    public record Word(
+            String word,
+            double start,
+            double end
     ) {
-        public record Word(
-                double start,
-                double end,
-                String word
-        ) {}
     }
 }

--- a/src/test/java/notai/client/ai/AiClientIntegrationTest.java
+++ b/src/test/java/notai/client/ai/AiClientIntegrationTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ByteArrayResource;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
@@ -36,10 +38,10 @@ class AiClientIntegrationTest {
     void STT_태스크_제출_통합_테스트() {
         // Given
         byte[] audioBytes = "test audio content".getBytes();
-        InputStream audioInputStream = new ByteArrayInputStream(audioBytes);
+        ByteArrayResource byteArrayResource = new ByteArrayResource(audioBytes);
 
         // When
-        TaskResponse response = aiClient.submitSttTask(audioInputStream);
+        TaskResponse response = aiClient.submitSttTask(byteArrayResource);
 
         // Then
         assertNotNull(response);

--- a/src/test/java/notai/client/ai/AiClientTest.java
+++ b/src/test/java/notai/client/ai/AiClientTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import static org.mockito.Mockito.*;
 import org.mockito.MockitoAnnotations;
+import org.springframework.core.io.ByteArrayResource;
 
 import java.io.InputStream;
 import java.util.UUID;
@@ -41,16 +42,16 @@ class AiClientTest {
     @Test
     void STT_테스크_전달_테스트() {
         // Given
-        InputStream inputStream = mock(InputStream.class);
+        ByteArrayResource byteArrayResource = mock(ByteArrayResource.class);
         UUID expectedTaskId = UUID.randomUUID();
         TaskResponse expectedResponse = new TaskResponse(expectedTaskId, "stt");
-        when(aiClient.submitSttTask(inputStream)).thenReturn(expectedResponse);
+        when(aiClient.submitSttTask(byteArrayResource)).thenReturn(expectedResponse);
 
         // When
-        TaskResponse response = aiClient.submitSttTask(inputStream);
+        TaskResponse response = aiClient.submitSttTask(byteArrayResource);
 
         // Then
         assertEquals(expectedResponse, response);
-        verify(aiClient, times(1)).submitSttTask(inputStream);
+        verify(aiClient, times(1)).submitSttTask(byteArrayResource);
     }
 }

--- a/src/test/java/notai/folder/application/FolderQueryServiceTest.java
+++ b/src/test/java/notai/folder/application/FolderQueryServiceTest.java
@@ -5,16 +5,19 @@ import notai.folder.domain.Folder;
 import notai.folder.domain.FolderRepository;
 import notai.member.domain.Member;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class FolderQueryServiceTest {
@@ -23,6 +26,14 @@ class FolderQueryServiceTest {
     private FolderRepository folderRepository;
     @InjectMocks
     private FolderQueryService folderQueryService;
+
+    @Mock
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        given(member.getId()).willReturn(1L);
+    }
 
     @Test
     @DisplayName("루트 폴더 조회")
@@ -33,7 +44,7 @@ class FolderQueryServiceTest {
 
         when(folderRepository.findAllByMemberIdAndParentFolderIsNull(any(Long.class))).thenReturn(expectedResults);
         //when
-        List<FolderFindResult> folders = folderQueryService.getFolders(1L, null);
+        List<FolderFindResult> folders = folderQueryService.getFolders(member, null);
 
         Assertions.assertThat(folders.size()).isEqualTo(1);
     }
@@ -50,7 +61,7 @@ class FolderQueryServiceTest {
         when(folderRepository.findAllByMemberIdAndParentFolderId(any(Long.class), any(Long.class))).thenReturn(
                 expectedResults);
         //when
-        List<FolderFindResult> folders = folderQueryService.getFolders(1L, 1L);
+        List<FolderFindResult> folders = folderQueryService.getFolders(member, 1L);
 
         Assertions.assertThat(folders.size()).isEqualTo(2);
     }

--- a/src/test/java/notai/llm/application/LlmTaskServiceTest.java
+++ b/src/test/java/notai/llm/application/LlmTaskServiceTest.java
@@ -21,19 +21,20 @@ import notai.problem.domain.Problem;
 import notai.problem.domain.ProblemRepository;
 import notai.summary.domain.Summary;
 import notai.summary.domain.SummaryRepository;
-import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class LlmTaskServiceTest {
@@ -69,7 +70,8 @@ class LlmTaskServiceTest {
         given(documentRepository.getById(anyLong())).willThrow(NotFoundException.class);
 
         // when & then
-        assertAll(() -> assertThrows(NotFoundException.class, () -> llmTaskService.submitTasks(command)),
+        assertAll(
+                () -> assertThrows(NotFoundException.class, () -> llmTaskService.submitTasks(command)),
                 () -> verify(documentRepository, times(1)).getById(documentId),
                 () -> verify(llmTaskRepository, never()).save(any(LlmTask.class))
         );
@@ -84,9 +86,10 @@ class LlmTaskServiceTest {
 
         Member member = new Member(new OauthId("12345", OauthProvider.KAKAO), "test@example.com", "TestUser");
         Folder folder = new Folder(member, "TestFolder");
-        Document document = new Document(folder, "TestDocument", "http://example.com/test.pdf", 43);
+        Document document = new Document(folder, member, "TestDocument", "http://example.com/test.pdf", 43);
 
-        List<Annotation> annotations = List.of(new Annotation(document, 1, 10, 20, 100, 50, "Annotation 1"),
+        List<Annotation> annotations = List.of(
+                new Annotation(document, 1, 10, 20, 100, 50, "Annotation 1"),
                 new Annotation(document, 1, 30, 40, 80, 60, "Annotation 2"),
                 new Annotation(document, 2, 50, 60, 120, 70, "Annotation 3")
         );
@@ -103,7 +106,8 @@ class LlmTaskServiceTest {
         LlmTaskSubmitResult result = llmTaskService.submitTasks(command);
 
         // then
-        assertAll(() -> verify(documentRepository, times(1)).getById(documentId),
+        assertAll(
+                () -> verify(documentRepository, times(1)).getById(documentId),
                 () -> verify(annotationRepository, times(1)).findByDocumentId(documentId),
                 () -> verify(aiClient, times(2)).submitLlmTask(any(LlmTaskRequest.class)),
                 () -> verify(llmTaskRepository, times(2)).save(any(LlmTask.class))
@@ -127,7 +131,8 @@ class LlmTaskServiceTest {
         Summary summary = mock(Summary.class);
         Problem problem = mock(Problem.class);
 
-        SummaryAndProblemUpdateCommand command = new SummaryAndProblemUpdateCommand(taskId,
+        SummaryAndProblemUpdateCommand command = new SummaryAndProblemUpdateCommand(
+                taskId,
                 summaryContent,
                 problemContent
         );
@@ -146,7 +151,8 @@ class LlmTaskServiceTest {
         Integer resultPageNumber = llmTaskService.updateSummaryAndProblem(command);
 
         // then
-        assertAll(() -> verify(taskRecord).completeTask(),
+        assertAll(
+                () -> verify(taskRecord).completeTask(),
                 () -> verify(summary).updateContent(summaryContent),
                 () -> verify(problem).updateContent(problemContent),
                 () -> verify(llmTaskRepository, times(1)).save(taskRecord),

--- a/src/test/java/notai/pageRecording/application/PageRecordingServiceTest.java
+++ b/src/test/java/notai/pageRecording/application/PageRecordingServiceTest.java
@@ -1,5 +1,8 @@
 package notai.pageRecording.application;
 
+import notai.document.domain.Document;
+import notai.document.domain.DocumentRepository;
+import notai.member.domain.Member;
 import notai.pageRecording.application.command.PageRecordingSaveCommand;
 import notai.pageRecording.application.command.PageRecordingSaveCommand.PageRecordingSession;
 import notai.pageRecording.domain.PageRecording;
@@ -8,13 +11,13 @@ import notai.recording.domain.Recording;
 import notai.recording.domain.RecordingRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.BDDMockito.given;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PageRecordingServiceTest {
@@ -28,23 +31,36 @@ class PageRecordingServiceTest {
     @Mock
     private RecordingRepository recordingRepository;
 
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @Mock
+    private Member member;
+
+    @Mock
+    private Document document;
+
     @Test
     void 페이지_넘김_이벤트에_따라_페이지별_녹음_시간을_저장() {
         // given
         Long recordingId = 1L;
         Long documentId = 1L;
 
-        PageRecordingSaveCommand command = new PageRecordingSaveCommand(recordingId,
+        PageRecordingSaveCommand command = new PageRecordingSaveCommand(
+                recordingId,
                 documentId,
                 List.of(new PageRecordingSession(1, 100.0, 185.5), new PageRecordingSession(5, 185.5, 290.3))
         );
 
         Recording foundRecording = mock(Recording.class);
         given(recordingRepository.getById(recordingId)).willReturn(foundRecording);
-        given(foundRecording.isRecordingOwnedByDocument(documentId)).willReturn(true);
+
+        given(documentRepository.getById(anyLong())).willReturn(document);
+        willDoNothing().given(document).validateOwner(member);
+        willDoNothing().given(foundRecording).validateDocumentOwnership(any(Document.class));
 
         // when
-        pageRecordingService.savePageRecording(command);
+        pageRecordingService.savePageRecording(member, command);
 
         // then
         verify(pageRecordingRepository, times(2)).save(any(PageRecording.class));

--- a/src/test/java/notai/recording/application/RecordingServiceTest.java
+++ b/src/test/java/notai/recording/application/RecordingServiceTest.java
@@ -6,10 +6,12 @@ import notai.common.utils.AudioDecoder;
 import notai.common.utils.FileManager;
 import notai.document.domain.Document;
 import notai.document.domain.DocumentRepository;
+import notai.member.domain.Member;
 import notai.recording.application.command.RecordingSaveCommand;
 import notai.recording.application.result.RecordingSaveResult;
 import notai.recording.domain.Recording;
 import notai.recording.domain.RecordingRepository;
+import notai.stt.application.SttTaskService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,11 +44,17 @@ class RecordingServiceTest {
     @Mock
     private DocumentRepository documentRepository;
 
+    @Mock
+    private SttTaskService sttTaskService;
+
     @Spy
     private final AudioDecoder audioDecoder = new AudioDecoder();
 
     @Spy
     private final FileManager fileManager = new FileManager();
+
+    @Mock
+    private Member member;
 
     @BeforeEach
     void setUp() {
@@ -70,7 +79,7 @@ class RecordingServiceTest {
 
         // when & then
         assertThrows(BadRequestException.class, () -> {
-            recordingService.saveRecording(command);
+            recordingService.saveRecording(member, command);
         });
     }
 
@@ -91,8 +100,10 @@ class RecordingServiceTest {
         given(recordingRepository.save(any(Recording.class))).willReturn(savedRecording);
         given(document.getName()).willReturn("안녕하세요백종원입니다");
 
+        willDoNothing().given(sttTaskService).submitSttTask(any());
+
         // when
-        RecordingSaveResult result = recordingService.saveRecording(command);
+        RecordingSaveResult result = recordingService.saveRecording(member, command);
 
         // then
         FilePath filePath = FilePath.from("안녕하세요백종원입니다_1.mp3");


### PR DESCRIPTION
## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요

### 회원의 자원 소유 검증
1. 인증 관련 argument resolver 에서 member를 반환하도록 수정
2. 문서 ID 를 포함하는 모든 api 엔드포인트에서 member 의 소유 검증, 관련 테스트 코드 수정


### OCR/STT 기능 개선
 1. OCR content 저장을 위한 컬럼 타입 변경 (text → longtext)
 2. STT 요청 시 ByteArrayResource 사용으로 스트림 재사용 문제 해결


### AI 서버 연동 개선
1. AI 서버 CallBack request 토큰 검증 제거
2. API 명세에 맞게 request dto 수정
3. STT 로깅 기능 추가


### 페이지 넘김 이벤트 관련 수정
1. 녹음 종료 시간 nullable 처리
2. 페이지 번호 0 허용하도록 validation 수정
3. EndTime null 케이스 예외 처리 추가


### 기타 버그 수정
1. filePath 컬럼 길이 제한 초과 오류 수정
2. Summary, Problem 각각 영속화하도록 수정
3. delete 응답 코드 수정 (204 → 200)
